### PR TITLE
check if $t is an array

### DIFF
--- a/carddav2fb.php
+++ b/carddav2fb.php
@@ -216,7 +216,7 @@ class CardDAV2FB {
 					foreach($vcard_obj->tel as $t) {
 
 						$prio = 0;
-						if (empty($t['Type'])) {
+						if (!is_array($t) || empty($t['Type'])) {
 							$type = "mobile";
 							$phone_number = $t;
 						} else {


### PR DESCRIPTION
Additional is_array check for phone number type, because when using a user defined type for a phone number, $t is not an array so empty($t['Type']) will raise an error and the number will not be imported.
