### PR TITLE
Remove reverse DNS stuff

### DIFF
--- a/carddav2fb.php
+++ b/carddav2fb.php
@@ -782,20 +782,6 @@ class CardDAV2FB
     }
     else
       print " ERROR: couldn't connect to FTP server '" . $ftp_server . "'." . PHP_EOL;
-
-    // in case numeric IP is given, try to resolve to hostname. Otherwise Fritzbox may decline login, because it is determine to be (prohibited) remote access
-    $hostname = $this->config['fritzbox_ip'];
-    if(filter_var($hostname, FILTER_VALIDATE_IP))
-    {
-      $hostname = gethostbyaddr($hostname);
-      if($hostname == $this->config['fritzbox_ip'])
-        print " WARNING: Unable to get hostname for IP address (" . $this->config['fritzbox_ip'] . ") <" . $hostname . "<" . PHP_EOL;
-      else
-      {
-        print " INFO: Given IP address (" . $this->config['fritzbox_ip'] . ") has hostname " . $hostname . "." . PHP_EOL;
-        $this->config['fritzbox_ip'] = $hostname;
-      }
-    }
     
     // lets post the phonebook xml to the FRITZ!Box
     print " Uploading Phonebook XML to " . $this->config['fritzbox_ip'] . PHP_EOL;

--- a/config.example.php
+++ b/config.example.php
@@ -2,7 +2,9 @@
 
 // CONFIG
 
-// DNS name of Fritz!Box or IP address
+// hostname or IP address of Fritz!Box
+// Note: Some Boxes are configured to reject login via IP.
+//       If that's the case with your box, then you have to specify the hostname.
 $config['fritzbox_ip'] = 'fritz.box';
 $config['fritzbox_ip_ftp'] = 'fritz.box';
 


### PR DESCRIPTION
_This scenario happened to me today:_
Imagine you have two Fritz!Boxes, of which both claim the hostname `fritz.box`.
If we do this crappy reverse DNS stuff and the hostname later resolves to a different IP, then
it is possible, that we accidentally update a different box.

Instead we should let the user decide, whether to connect with hostname or IP.

---
If a box really needs the user to log in via hostname and connecting is only possible via IP, then we anyway would have to change `fritzbox_api_php` to send the hostname in http headers.