### PR TITLE
Fallback to formatted name if available

### DIFF
--- a/carddav2fb.php
+++ b/carddav2fb.php
@@ -248,6 +248,7 @@ class CardDAV2FB
           $prefix = '';
           $suffix = '';
           $orgname = '';
+          $formattedname = '';
 
           // Build name Parts if existing ans switch to true in config
           if(isset($name_arr['prefixes']) and $this->config['prefix'])
@@ -261,6 +262,9 @@ class CardDAV2FB
 
           if(isset($org_arr['name']) and $this->config['orgname'])
             $orgname = trim($org_arr['name']);
+
+          if (isset($vcard_obj->fn[0]))
+            $formattedname = $vcard_obj->fn[0];
 
           $firstname = trim($name_arr['firstname']);
           $lastname = trim($name_arr['lastname']);
@@ -349,9 +353,13 @@ class CardDAV2FB
           // make sure to trim whitespaces and double spaces
           $name = trim(str_replace('  ', ' ', $name));
 
+          // perform a fallback to formatted name, if we don't have any name and formatted name is available
+          if(empty($name) and !empty($formattedname))
+            $name = $formattedname;
+
           if(empty($name))
           {
-            print '  WARNING: No fullname, lastname or orgname found!';
+            print '  WARNING: No fullname, lastname, orgname or formatted name found!' . PHP_EOL;
             $name = 'UNKNOWN';
           }
 


### PR DESCRIPTION
I installed a brand new version of owncloud and created some new contacts in the web UI.
The script could not determine the contact names.

The RAW data of an example vcard looked like this.

```
BEGIN:VCARD
VERSION:3.0
FN:Mike Kunze
UID:bc44600d-ff0f-4400-89b1-518e39d6a0d8
TEL;TYPE=HOME\,VOICE:06439 69 75 74
END:VCARD
```
No name property was included, but there is a formatted name. I think this is the default behavior when a contact is created directly in the web application.

In this pull request a fallback to the formatted name is done, if no name could be determined and formatted name is available.
Also a new line is added to the warning message.