### PR TITLE
Add jpeg MIME type to contact photo check

### DIFF
--- a/carddav2fb.php
+++ b/carddav2fb.php
@@ -576,7 +576,7 @@ class CardDAV2FB
         {
           // check if photo_data really contains JPEG data
           if((array_key_exists('type', $entry['photo_data'][0])) and (is_array($entry['photo_data'][0]['type'])) and
-             ($entry['photo_data'][0]['type'][0] == 'jpeg' or $entry['photo_data'][0]['type'][0] == 'jpg'))
+             ($entry['photo_data'][0]['type'][0] == 'jpeg' or $entry['photo_data'][0]['type'][0] == 'jpg' or $entry['photo_data'][0]['type'][0] == 'image/jpeg'))
           {
             // get photo, rename, base64 convert and save as jpg
             $photo_data = $entry['photo_data'][0]['value'];


### PR DESCRIPTION
In my test installation (nextcloud with contacts created in the web UI) the value of `$entry['photo_data'][0]['type'][0]` is `image/jpeg`, so the previously implemented file type validation failed.

This pull request adds `image/jpeg` to the condition.