### PR TITLE
Allow * and # in phone numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Now you should have everything setup and checked out to a 'carddav2fb' directory
 	$config['addnames'] = false; // include additionalnames in fullname if existing
 	$config['orgname'] = false; // include organisation (company) in fullname if existing
 	
-	$config['quickdial_keyword'] = 'Quickdial:'; // once activated you may add 'Quickdial:+49030123456:**709' to the contact note field and the number will be set as quickdialnumber in your FRITZ!Box. It is possible to add more quickdials for one contact each in a new line
+	$config['quickdial_keyword'] = 'Quickdial:'; // once activated you may add 'Quickdial:+49030123456:**709' to the contact note field and the number will be set as quickdialnumber in your FRITZ!Box. It is possible to add more quickdials for one contact each in a new line. The number used in in the quickdialnote must be found in as phonenumber in the contact as well.
 
 	// first
 	$config['carddav'][0] = array(
@@ -97,4 +97,4 @@ This script is using third-party libraries for downloading VCards from CardDAV s
 This script is released under Public Domain.
 
 ## Authors
-Copyright (c) 2012-2016 Karl Glatz, Martin Rost, Jens Maus, Johannes Freiburger
+Copyright (c) 2012-2016 Karl Glatz, Martin Rost, Jens Maus, Johannes Freiburger, holzhannes

--- a/carddav2fb.php
+++ b/carddav2fb.php
@@ -17,6 +17,7 @@
  *         Martin Rost
  *         Jens Maus <mail@jens-maus.de>
  *         Johannes Freiburger
+ *         holzhannes <holzhannes@posteo.de>
  *
  */
 error_reporting(E_ALL);
@@ -70,7 +71,7 @@ else
 // ---------------------------------------------
 // MAIN
 print "carddav2fb.php " . $carddav2fb_version . " - CardDAV to FRITZ!Box phonebook conversion tool" . PHP_EOL;
-print "Copyright (c) 2012-2016 Karl Glatz, Martin Rost, Jens Maus, Johannes Freiburger" . PHP_EOL . PHP_EOL;
+print "Copyright (c) 2012-2016 Karl Glatz, Martin Rost, Jens Maus, Johannes Freiburger, holzhannes" . PHP_EOL . PHP_EOL;
 
 $client = new CardDAV2FB($config);
 
@@ -392,7 +393,7 @@ class CardDAV2FB
               if($found > 0)
               {
                 $pos_qd_start = strrpos($linecontent, ":**7");
-                $quick_dial_for_nr = preg_replace("/[^0-9+]/", "", substr($linecontent, 0, $pos_qd_start));
+                $quick_dial_for_nr = $this->_clear_phone_number(substr($linecontent, 0, $pos_qd_start));
                 $quick_dial_nr = intval(substr($linecontent, $pos_qd_start + 4, 3));
                 $quick_dial_arr[$quick_dial_for_nr] = $quick_dial_nr;
               }
@@ -434,7 +435,7 @@ class CardDAV2FB
               {
                 $phone_number = $t['value'];
                 
-                $phone_number_clean = preg_replace("/[^0-9+]/", "", $phone_number);
+                $phone_number_clean = $this->_clear_phone_number($phone_number);
                 foreach($quick_dial_arr as $qd_phone_nr => $value)
                 {
                   if($qd_phone_nr == $phone_number_clean)
@@ -517,7 +518,7 @@ class CardDAV2FB
 
   private function _clear_phone_number($number)
   {
-    return preg_replace("/[^0-9+]/", "", $number);
+    return preg_replace("/[^0-9+*#]/", "", $number);
   }
 
   public function build_fb_xml()


### PR DESCRIPTION
This commit will allow you to add * and # characters to your phonebook via carddav2fb. Therefore it is possible to control the calling behaviour or save internal FB numbers to the phonebook as well. 
For example you now may control through which account you like to dial a number by adding an extra phone entry for the contact `*121#0049123456`, If you call it it the call will be handeled through the first VOIP account in your FRITZ!Box or you may add `*31#` as prefix for some numbers to call them without sending your caller id.