### PR TITLE
Include phone numbers with custom label

### DIFF
--- a/carddav2fb.php
+++ b/carddav2fb.php
@@ -475,7 +475,7 @@ class CardDAV2FB
                 elseif(in_array("voice", $typearr_lower))
                   $type = "other";
                 else
-                  continue;
+                  $type = "other";
               }
               $phone_no[] = array("type"=>$type, "prio"=>$prio, "quickdial"=>$quickdial, "value" => $this->_clear_phone_number($phone_number));
             }


### PR DESCRIPTION
Problem: Currently all carddav phone numbers with a custom label (X-ABLABEL) are ignored during FritzBox phone book construction.
Fix: This pull request sets `$type = "other"` for all non-matching phone labels.